### PR TITLE
Updated to V9 and PHP8.2 compatibility. Removed deprecated functions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+4.0.0
+- V9 and PHP 8.2 Compatibiity
+
 3.1.1
 - Add install notes.
 

--- a/blocks/d3_mailchimp/controller.php
+++ b/blocks/d3_mailchimp/controller.php
@@ -10,6 +10,7 @@ use Concrete\Core\Block\BlockController;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Validator\String\EmailValidator;
 use Exception;
 
 class Controller extends BlockController
@@ -83,7 +84,7 @@ class Controller extends BlockController
         }
     }
     
-    public function action_submit($bId = false)
+    public function action_submit($bID = false)
     {
         if (!Request::isPost()) {
             $this->view();
@@ -91,7 +92,8 @@ class Controller extends BlockController
             return;
         }
 
-        if ($bId !== $this->bID) {
+        $bID = (int) $bID;
+        if ($bID !== $this->bID) {
             $this->view();
 
             return;
@@ -101,7 +103,8 @@ class Controller extends BlockController
             $this->error->add(t('Invalid token'));
         }
 
-        if (!$this->app->make('helper/validation/strings')->email($this->post('email_address'))) {
+	    $validator = $this->app->make(EmailValidator::class, ['testMXRecord' => false, 'strict' => false]);
+        if (!$validator->isValid($this->post('email_address'))) {
             $this->error->add(t('Invalid email address'));
         }
 
@@ -120,6 +123,12 @@ class Controller extends BlockController
 
     public function add()
     {
+    	$this->set('listId', null);
+    	$this->set('subscribeAction', null);
+    	$this->set('styling', null);
+    	$this->set('showTermsCheckbox', null);
+    	$this->set('acceptTermsText', null);
+    	$this->set('mergeFields', null);
         $this->addEdit();
     }
 

--- a/blocks/d3_mailchimp/view.php
+++ b/blocks/d3_mailchimp/view.php
@@ -1,5 +1,7 @@
 <?php
 
+use Concrete\Core\Error\ErrorList\Formatter\StandardFormatter;
+
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /** @var Concrete\Core\Validation\CSRF\Token $token */
@@ -12,8 +14,9 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <div class="d3-mailchimp" data-block-id="<?php echo $bID; ?>">
 	<?php 
-	if (isset($errors)) {
-		$errors->output();
+	if (isset($errors) && $errors->has()) {
+		$formatter = new StandardFormatter($errors);
+		echo $formatter->render();
 	}
 	
 	if (isset($message)) {

--- a/controller.php
+++ b/controller.php
@@ -4,18 +4,18 @@ namespace Concrete\Package\D3Mailchimp;
 
 use A3020\D3Mailchimp\Installer;
 use Concrete\Core\Package\Package;
-use Concrete\Core\Support\Facade\Package as PackageFacade;
+use Concrete\Core\Package\PackageService;
 
 class Controller extends Package
 {
     protected $pkgHandle = 'd3_mailchimp';
-    protected $appVersionRequired = '8.0';
-    protected $pkgVersion = '3.1.1';
+    protected $appVersionRequired = '9.0';
+    protected $pkgVersion = '4.0.0';
     protected $pkgAutoloaderRegistries = [
         'src/D3Mailchimp' => '\A3020\D3Mailchimp',
     ];
 
-    public function getPackageName()
+	public function getPackageName()
     {
         return t('MailChimp Subscribe');
     }
@@ -35,7 +35,7 @@ class Controller extends Package
 
     public function upgrade()
     {
-        $pkg = PackageFacade::getByHandle($this->pkgHandle);
+	    $pkg = $this->app->make(PackageService::class)->getByHandle($this->pkgHandle);
 
         $installer = $this->app->make(Installer::class);
         $installer->install($pkg);

--- a/controllers/single_page/dashboard/system/mail/mailchimp.php
+++ b/controllers/single_page/dashboard/system/mail/mailchimp.php
@@ -4,6 +4,7 @@ namespace Concrete\Package\D3Mailchimp\Controller\SinglePage\Dashboard\System\Ma
 
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Routing\RedirectResponse;
 
 class Mailchimp extends DashboardPageController
 {
@@ -22,7 +23,7 @@ class Mailchimp extends DashboardPageController
 
         if ($token->validate('d3_mailchimp.settings.save')) {
             $config->save('d3_mailchimp.settings.api_key',  $this->post('api_key'));
-            $this->redirect($this->action('save_success'));
+            return new RedirectResponse($this->action('save_success'));
         } else {
             $this->error->add($token->getErrorMessage());
         }


### PR DESCRIPTION
Following on from https://forums.concretecms.org/t/sending-group-emails/7090/8 I have this working on Version 9 and PHP 8.2. There wasn't that much to do really. Fixed a few undefined variable issues when adding the block, and removed deprecated functions, but the main issue was the subscribe function that didn't work in V9 because the two bID variables are of different types in V9. Updated package version to 4.0.0  to distinguish from earlier versions.